### PR TITLE
顔写真登録の実装。未登録時の表示不具合を修正

### DIFF
--- a/frontend/src/pages/EmployeeListPage.tsx
+++ b/frontend/src/pages/EmployeeListPage.tsx
@@ -163,20 +163,22 @@ const EmployeeListPage = () => {
             <tr className="row" key={employee.id}>
               <td className="col-1">{employee.id}</td>
               <td className="col-1">
-                <img
-                  src={imageMap[employee.id] || ''}
-                  alt="顔写真"
-                  width="50"
-                  height="50"
-                  style={{
-                    objectFit: 'cover',
-                    border: '1px solid #ccc', // 枠線
-                    backgroundColor: '#f9f9f9', // 背景色
-                  }}
-                  onError={(e) => {
-                    (e.target as HTMLImageElement).src = '';
-                  }}
-                />
+                {imageMap[employee.id] && (
+                  <img
+                    src={imageMap[employee.id] || ''}
+                    alt="顔写真"
+                    width="50"
+                    height="50"
+                    style={{
+                      objectFit: 'cover',
+                      border: '1px solid #ccc', // 枠線
+                      backgroundColor: '#f9f9f9', // 背景色
+                    }}
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).src = '';
+                    }}
+                  />
+                )}
               </td>
               <td className="col-2">{employee.name}</td>
               <td className="col-5">{employee.email}</td>


### PR DESCRIPTION
## 概要

顔写真登録の実装。未登録時の表示不具合を修正

## 変更内容

社員一覧画面、顔写真の未登録時にリンク切れ表示になる不具合を修正した。

## スクリーンショット（UI 変更がある場合）

Before
![1_before](https://github.com/user-attachments/assets/ad22fec2-61f1-4b62-af55-8ac8dc835652)

After
![2_after](https://github.com/user-attachments/assets/a7821f49-81b9-49e4-9bf3-98e7fe83771e)


## テスト観点・確認項目

- [ ] 正常系：期待どおりに動作すること
    - 顔写真を登録した時は、顔写真が表示されること
- [ ] 異常系：エラー処理が正しく行われること
    - 顔写真を未登録の時は、何も表示されないこと(リンク切れ表示にならない)
    
## 補足

<!-- レビューしてほしいポイントや、今後のTODOなど -->
